### PR TITLE
Made prev/next buttons disappear on use of navbar links

### DIFF
--- a/app/js/questionNav.js
+++ b/app/js/questionNav.js
@@ -43,7 +43,7 @@ function changeQuestion(destinationPage) {
     let prevButton = document.querySelector(".prev")
     document.querySelector("h4").textContent = destinationPage + "/" + questionCount
 
-    switch(destinationPage) {
+    switch(parseInt(destinationPage)) { // parseInt() in case a string is passed
         case 1:
             prevButton.style.display = "none"
             nextButton.style.display = "block"


### PR DESCRIPTION
The destinationPage parameter was passed into changeQuestion() as a string by fillNav(), & the switch statement only worked with integers.  Using parseInt() in the switch statement fixes this.