### PR TITLE
Script load ordering hotfix

### DIFF
--- a/app/addQuestion.html
+++ b/app/addQuestion.html
@@ -9,14 +9,14 @@
     <link href="css/styles.css" type="text/css" rel="stylesheet">
     <link href="css/adminPage.css" type="text/css" rel="stylesheet">
     <link rel="stylesheet" type="text/css" href="css/addQuestion.css">
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/handlebars.js/4.4.2/handlebars.js" defer></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/handlebars.js/4.4.2/handlebars.js"></script>
     <script src="js/aptitudeTestHelpers.js" defer></script>
     <script src="js/utils.js"></script>
     <script defer src="js/userLogIn.js"></script>
     <script defer src="js/cookies.js"></script>
     <script defer src="js/questionCount.js"></script>
-    <script defer src="js/sendData.js"></script>
-    <script defer src="js/getData.js"></script>
+    <script src="js/sendData.js"></script>
+    <script src="js/getData.js"></script>
     <script defer src="js/populateHandlebars.js"></script>
     <script defer src="js/sendQuestionFormOutput.js"></script>
     <script defer src="js/ajaxHandlebarsTemplate.js"></script>

--- a/app/addQuestion.html
+++ b/app/addQuestion.html
@@ -9,15 +9,15 @@
     <link href="css/styles.css" type="text/css" rel="stylesheet">
     <link href="css/adminPage.css" type="text/css" rel="stylesheet">
     <link rel="stylesheet" type="text/css" href="css/addQuestion.css">
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/handlebars.js/4.4.2/handlebars.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/handlebars.js/4.4.2/handlebars.js" defer></script>
     <script src="js/aptitudeTestHelpers.js" defer></script>
     <script src="js/utils.js"></script>
     <script defer src="js/userLogIn.js"></script>
     <script defer src="js/cookies.js"></script>
     <script defer src="js/questionCount.js"></script>
     <script defer src="js/sendData.js"></script>
-    <script async src="js/getData.js"></script>
-    <script async src="js/populateHandlebars.js"></script>
+    <script defer src="js/getData.js"></script>
+    <script defer src="js/populateHandlebars.js"></script>
     <script defer src="js/sendQuestionFormOutput.js"></script>
     <script defer src="js/ajaxHandlebarsTemplate.js"></script>
     <title>Add Question</title>

--- a/app/addQuestion.html
+++ b/app/addQuestion.html
@@ -15,9 +15,9 @@
     <script defer src="js/userLogIn.js"></script>
     <script defer src="js/cookies.js"></script>
     <script defer src="js/questionCount.js"></script>
-    <script src="js/sendData.js"></script>
+    <script defer src="js/sendData.js"></script>
     <script src="js/getData.js"></script>
-    <script defer src="js/populateHandlebars.js"></script>
+    <script src="js/populateHandlebars.js"></script>
     <script defer src="js/sendQuestionFormOutput.js"></script>
     <script defer src="js/ajaxHandlebarsTemplate.js"></script>
     <title>Add Question</title>

--- a/app/adminPage.html
+++ b/app/adminPage.html
@@ -18,8 +18,8 @@
             }
         })
     </script>
-    <script src="js/getData.js" async></script>
-    <script src="js/populateHandlebars.js" async></script>
+    <script src="js/getData.js"></script>
+    <script src="js/populateHandlebars.js"></script>
     <script src="js/adminPage.js" defer></script>
     <script src="js/ajaxHandlebarsTemplate.js" defer></script>
     <script src="js/createUserObject.js" defer></script>

--- a/app/scss/adminPage.scss
+++ b/app/scss/adminPage.scss
@@ -140,11 +140,3 @@ body {
 #addTestName {
   margin-bottom: 10px;
 }
-
-.success-message {
-  color: $success-message;
-}
-
-.failure-message {
-  color: $failure-message
-}


### PR DESCRIPTION
The script ordering on the admin and ask question pages was creating a bug whereby the fetch request wasn't returning data in time reliably

Also took off unnecessary CSS from error messages (because bootstrap handles these instead)