### PR TITLE
Timer double logging fixed. Moved clearInterval to end test state

### DIFF
--- a/app/js/checkAnswers.js
+++ b/app/js/checkAnswers.js
@@ -129,6 +129,7 @@ function trackActiveQuestion(id) {
  */
 function showResults() {
     resetReapplyCounter()
+    clearInterval(interval)
     const userAnswers = getUserAnswers(questionAmount)
     checkAnswers(userAnswers).then(function (result) {
         let percentResult

--- a/app/js/timer.js
+++ b/app/js/timer.js
@@ -34,7 +34,6 @@ function timer() {
     })
     timeRemaining--
     if (timeRemaining < 0) {
-        clearInterval(interval)
         showResults()
     }
 }


### PR DESCRIPTION
Moved the clearInterval to the showResults() function in checkAnswers.js to avoid double logging when the timer runs out on the end screen.