### PR TITLE
S1 ta5 populate dropdown

### DIFF
--- a/app/js/adminPage.js
+++ b/app/js/adminPage.js
@@ -1,4 +1,9 @@
+//Populate drop down options on page load in 'add new user' and 'manage questions' sections
 populateHandlebars('#test_id', 'js/templates/testDropdown.hbs', 'test')
+populateHandlebars('#selectTest', 'js/templates/testDropdown.hbs', 'test')
+populateHandlebars('#selectQuestion', 'js/templates/questionDropdown.hbs', 'question')
+populateHandlebars('#selectTestDelete', 'js/templates/testDropdown.hbs', 'test')
+populateHandlebars('#selectQuestionDelete', 'js/templates/questionDropdown.hbs', 'question')
 
 /**
  * Save the JSON object using an AJAX request.
@@ -82,6 +87,18 @@ function userExists(emailToAdd, existingUsers) {
 
     return result
 }
+
+//Within manage question section, an event listener on the test dropdown which populates the EDIT question dropdown, when selected
+document.getElementById('selectTest').addEventListener('change', function () {
+    let selectorTestId = this.value
+    populateHandlebars('#selectQuestion', 'js/templates/questionDropdown.hbs', `question?test_id=${selectorTestId}`)
+})
+
+//Within manage question section, an event listener on the test dropdown which populates the DELETE question dropdown, when selected
+document.getElementById('selectTestDelete').addEventListener('change', function () {
+    let selectorTestId = this.value
+    populateHandlebars('#selectQuestionDelete', 'js/templates/questionDropdown.hbs', `question?test_id=${selectorTestId}`)
+})
 
 document.querySelector('#addNewUserForm').addEventListener('submit', function(event) {
     event.preventDefault()

--- a/app/js/newTest.js
+++ b/app/js/newTest.js
@@ -23,4 +23,8 @@ testForm.addEventListener('submit', async function(e) {
         responseMsg.classList.add('alert-danger')
         responseMsg.innerHTML = 'Test name must be between 1 and 255 characters.'
     }
+    populateHandlebars('#selectTest', 'js/templates/testDropdown.hbs', 'test')
+    populateHandlebars('#selectTestDelete', 'js/templates/testDropdown.hbs', 'test')
+    populateHandlebars('#selectQuestion', 'js/templates/questionDropdown.hbs', 'question')
+    populateHandlebars('#selectQuestionDelete', 'js/templates/questionDropdown.hbs', 'question')
 })

--- a/app/js/templates/questionDropdown.hbs
+++ b/app/js/templates/questionDropdown.hbs
@@ -1,3 +1,3 @@
-{{#each question}}
-    <option value="{{id}}" id="questionId_{{test_id}}">{{text}}</option>
+{{#each data}}
+    <option value="{{id}}" id="testId_{{test_id}}">{{text}}</option>
 {{/each}}

--- a/app/js/templates/questionDropdown.hbs
+++ b/app/js/templates/questionDropdown.hbs
@@ -1,0 +1,3 @@
+{{#each question}}
+    <option value="{{id}}" id="questionId_{{test_id}}">{{text}}</option>
+{{/each}}

--- a/app/js/templates/testAndQuestionDropdown.hbs
+++ b/app/js/templates/testAndQuestionDropdown.hbs
@@ -1,0 +1,7 @@
+{{#each test}}
+    <option value="{{id}}">{{name}}</option>
+{{/each}}
+
+{{#each question}}
+    <option value="{{id}}" id="questionId_{{test_id}}">{{text}}</option>
+{{/each}}

--- a/app/js/templates/testAndQuestionDropdown.hbs
+++ b/app/js/templates/testAndQuestionDropdown.hbs
@@ -1,7 +1,0 @@
-{{#each test}}
-    <option value="{{id}}">{{name}}</option>
-{{/each}}
-
-{{#each question}}
-    <option value="{{id}}" id="questionId_{{test_id}}">{{text}}</option>
-{{/each}}

--- a/app/scss/adminPage.scss
+++ b/app/scss/adminPage.scss
@@ -119,6 +119,7 @@ body {
 
 .new-question-container select {
   margin: 0 10px 0 3px;
+  width: 130px;
 }
 
 #current-question-count {


### PR DESCRIPTION
Deliverables:
Populate the manage questions drop down boxes for tests and the relevant questions with correct data. 
Must work for both edit and delete drop downs.
Must work on...
	-> on page load 
	-> when new test added
	-> when questions are deleted, are not shown on reload

