### PR TITLE
S16 provide score breakdowns

### DIFF
--- a/app/adminPage.html
+++ b/app/adminPage.html
@@ -61,6 +61,7 @@
         <button class="open-view-answers-tab primary-button">Answers</button>
         <button class="open-view-breakdown-tab primary-button">Breakdown</button>
         <div id="view-results-modal-content"></div>
+        <div id="view-results-breakdown-modal-content"></div>
     </div>
     <section class="container">
         <img class="logo" alt="iO Academy Logo" src="./images/logos/SVGs/iO_Logo_Alt.svg">

--- a/app/adminPage.html
+++ b/app/adminPage.html
@@ -58,6 +58,8 @@
     </div>
     <div id="view-results-modal">
         <button class="close-view-results primary-button">Close</button>
+        <button class="primary-button">Answers</button>
+        <button class="primary-button">Breakdown</button>
         <div id="view-results-modal-content"></div>
     </div>
     <section class="container">

--- a/app/adminPage.html
+++ b/app/adminPage.html
@@ -58,8 +58,8 @@
     </div>
     <div id="view-results-modal">
         <button class="close-view-results primary-button">Close</button>
-        <button class="primary-button">Answers</button>
-        <button class="primary-button">Breakdown</button>
+        <button class="open-view-answers-tab primary-button">Answers</button>
+        <button class="open-view-breakdown-tab primary-button">Breakdown</button>
         <div id="view-results-modal-content"></div>
     </div>
     <section class="container">

--- a/app/js/handlebarsScoreTable.ts
+++ b/app/js/handlebarsScoreTable.ts
@@ -284,15 +284,6 @@ async function addEventListenersForViewResults() {
                     userData.data.forEach(user =>{
                         if (user.id === resultData.data.id) {
                             let testId = user.test_id
-                            // Removes Answers/Breakdown tab buttons from view results modal if not test 1
-                            // Remove this if you ever want to display a breakdown for a test with test_id that isn't 1
-                            if (testId != 1) {
-                                document.querySelector<HTMLButtonElement>('.open-view-answers-tab').style.display = 'none';
-                                document.querySelector<HTMLButtonElement>('.open-view-breakdown-tab').style.display = 'none';
-                            } else {
-                                document.querySelector<HTMLButtonElement>('.open-view-answers-tab').style.display = 'inline-block';
-                                document.querySelector<HTMLButtonElement>('.open-view-breakdown-tab').style.display = 'inline-block';
-                            }
                             getData("question?test_id=" + testId).then(questionData => {
                                 resultsTable.innerHTML = template(createUserResults(resultData, questionData));
                             })

--- a/app/js/handlebarsScoreTable.ts
+++ b/app/js/handlebarsScoreTable.ts
@@ -329,6 +329,8 @@ function addEventListenerForAnswersTabButton(): void {
 function displayResultsTableTab(): void {
     document.querySelector<HTMLElement>("#view-results-modal-content").style.display = "block";
     document.querySelector<HTMLElement>("#view-results-breakdown-modal-content").style.display = "none";
+    document.querySelector<HTMLElement>(".open-view-answers-tab").classList.add("active-tab");
+    document.querySelector<HTMLElement>(".open-view-breakdown-tab").classList.remove("active-tab");
 }
 
 /**
@@ -338,6 +340,8 @@ function addEventListenerForBreakdownTabButton(): void {
     document.querySelector(".open-view-breakdown-tab").addEventListener("click", () => {
         document.querySelector<HTMLElement>("#view-results-modal-content").style.display = "none";
         document.querySelector<HTMLElement>("#view-results-breakdown-modal-content").style.display = "block";
+        document.querySelector<HTMLElement>(".open-view-answers-tab").classList.remove("active-tab");
+        document.querySelector<HTMLElement>(".open-view-breakdown-tab").classList.add("active-tab");
     });
 }
 

--- a/app/js/handlebarsScoreTable.ts
+++ b/app/js/handlebarsScoreTable.ts
@@ -282,6 +282,7 @@ async function addEventListenersForViewResults() {
     let resultsBreakdownTable: Element = document.querySelector("#view-results-breakdown-modal-content");
     document.querySelectorAll(".view-results-button").forEach((button) => {
         button.addEventListener("click", (e: any) => {
+            displayResultsTableTab();
             openViewResultsModal();
             addEventListenersForCloseResults();
             getData("result?id=" + e.target.getAttribute("dataId")).then(resultData => {
@@ -319,10 +320,15 @@ function addEventListenersForCloseResults() {
  * function to add a click event listener to the view results modal answers tab button that displays the results table in the modal
  */
 function addEventListenerForAnswersTabButton(): void {
-    document.querySelector(".open-view-answers-tab").addEventListener("click", () => {
-        document.querySelector<HTMLElement>("#view-results-modal-content").style.display = "block"
-        document.querySelector<HTMLElement>("#view-results-breakdown-modal-content").style.display = "none"
-    })
+    document.querySelector(".open-view-answers-tab").addEventListener("click", displayResultsTableTab);
+}
+
+/**
+ * function to display the results table in the view results modal
+ */
+function displayResultsTableTab(): void {
+    document.querySelector<HTMLElement>("#view-results-modal-content").style.display = "block";
+    document.querySelector<HTMLElement>("#view-results-breakdown-modal-content").style.display = "none";
 }
 
 /**
@@ -330,9 +336,9 @@ function addEventListenerForAnswersTabButton(): void {
  */
 function addEventListenerForBreakdownTabButton(): void {
     document.querySelector(".open-view-breakdown-tab").addEventListener("click", () => {
-        document.querySelector<HTMLElement>("#view-results-modal-content").style.display = "none"
-        document.querySelector<HTMLElement>("#view-results-breakdown-modal-content").style.display = "block"
-    })
+        document.querySelector<HTMLElement>("#view-results-modal-content").style.display = "none";
+        document.querySelector<HTMLElement>("#view-results-breakdown-modal-content").style.display = "block";
+    });
 }
 
 function addEventListenersForMoreInfoButtons() {

--- a/app/js/handlebarsScoreTable.ts
+++ b/app/js/handlebarsScoreTable.ts
@@ -159,7 +159,9 @@ function produceTable (HBTemplate: string, scoresDataObject) {
     addDeleteEventListeners();
     addEventListenersForDownloadButtons();
     addEventListenersForViewResults();
-    addEventListenersForMoreInfoButtons()
+    addEventListenersForMoreInfoButtons();
+    addEventListenerForAnswersTabButton();
+    addEventListenerForBreakdownTabButton();
 }
 
 function createUserResults(resultData, questionData): Object {
@@ -311,6 +313,26 @@ function addEventListenersForCloseResults() {
             closeViewResultsModal();
         });
     });
+}
+
+/**
+ * function to add a click event listener to the view results modal answers tab button that displays the results table in the modal
+ */
+function addEventListenerForAnswersTabButton(): void {
+    document.querySelector(".open-view-answers-tab").addEventListener("click", () => {
+        document.querySelector<HTMLElement>("#view-results-modal-content").style.display = "block"
+        document.querySelector<HTMLElement>("#view-results-breakdown-modal-content").style.display = "none"
+    })
+}
+
+/**
+ * function to add a click event listener to the view results modal answers tab button that displays the results breakdown table in the modal
+ */
+function addEventListenerForBreakdownTabButton(): void {
+    document.querySelector(".open-view-breakdown-tab").addEventListener("click", () => {
+        document.querySelector<HTMLElement>("#view-results-modal-content").style.display = "none"
+        document.querySelector<HTMLElement>("#view-results-breakdown-modal-content").style.display = "block"
+    })
 }
 
 function addEventListenersForMoreInfoButtons() {

--- a/app/js/handlebarsScoreTable.ts
+++ b/app/js/handlebarsScoreTable.ts
@@ -220,6 +220,15 @@ async function addEventListenersForViewResults() {
                     userData.data.forEach(user =>{
                         if (user.id === resultData.data.id) {
                             let testId = user.test_id
+                            // Removes Answers/Breakdown tab buttons from view results modal if not test 1
+                            // Remove this if you ever want to display a breakdown for a test with test_id that isn't 1
+                            if (testId != 1) {
+                                document.querySelector<HTMLButtonElement>('.open-view-answers-tab').style.display = 'none';
+                                document.querySelector<HTMLButtonElement>('.open-view-breakdown-tab').style.display = 'none';
+                            } else {
+                                document.querySelector<HTMLButtonElement>('.open-view-answers-tab').style.display = 'inline-block';
+                                document.querySelector<HTMLButtonElement>('.open-view-breakdown-tab').style.display = 'inline-block';
+                            }
                             getData("question?test_id=" + testId).then(questionData => {
                                 resultsTable.innerHTML = template(createUserResults(resultData, questionData));
                             })

--- a/app/js/handlebarsScoreTable.ts
+++ b/app/js/handlebarsScoreTable.ts
@@ -186,6 +186,70 @@ function createUserResults(resultData, questionData): Object {
     return userResultsTable;
 }
 
+interface ResultsBreakdownSection {
+    name: string;
+    score: number;
+    questions: number;
+    percentage: number;
+    startingQuestionNumber?: number;
+    finalQuestionNumber?: number;
+}
+
+interface ResultsBreakdown {
+    sections: ResultsBreakdownSection[];
+}
+
+/**
+ * function to create a ResultsBreakdown object for a user using their result data object for use in creating a user results breakdown table
+ *
+ * @param {object} resultData object containing retrieved result data for the user
+ * @param {string} test_id test_id for the test the user's been assigned
+ *
+ * @returns {Promise<ResultsBreakdown>} object containing the results breakdown
+ */
+async function createUserResultsBreakdown(resultData, test_id: string): Promise<ResultsBreakdown> {
+    let breakdown: ResultsBreakdown = {
+        sections: []
+    };
+
+    // Remove this if statement if you ever want to display a breakdown for a test with test_id that isn't 1
+    if (test_id == "1") {
+        breakdown.sections.push({name: 'Starter', score: 0, questions: 0, percentage: 0, startingQuestionNumber: 1, finalQuestionNumber: 3});
+        breakdown.sections.push({name: 'Comparison', score: 0, questions: 0, percentage: 0, startingQuestionNumber: 4, finalQuestionNumber: 8});
+        breakdown.sections.push({name: 'Syntax', score: 0, questions: 0, percentage: 0, startingQuestionNumber: 9, finalQuestionNumber: 13});
+        breakdown.sections.push({name: 'Procedure', score: 0, questions: 0, percentage: 0, startingQuestionNumber: 14, finalQuestionNumber: 18});
+        breakdown.sections.push({name: 'Logic', score: 0, questions: 0, percentage: 0, startingQuestionNumber: 19, finalQuestionNumber: 23});
+        breakdown.sections.push({name: 'Sequence', score: 0, questions: 0, percentage: 0, startingQuestionNumber: 24, finalQuestionNumber: 30});
+    }
+
+    let testName = 'Test'
+    let testData = await getData("test")
+    testData.data.forEach(test => {
+        if (test.id == test_id) {
+            testName = test.name
+        }
+    })
+    breakdown.sections.push({name: testName, score: 0, questions: 0, percentage: 0});
+    let userResults: Object = JSON.parse(JSON.parse(resultData.data.answers));
+    let questionNumber = 1;
+    for (let result in userResults) {
+        breakdown.sections.forEach(section => {
+            if ((!section.startingQuestionNumber || !section.finalQuestionNumber)
+                || (questionNumber >= section.startingQuestionNumber && questionNumber <= section.finalQuestionNumber)) {
+                section.questions++;
+                if (userResults[result]["isCorrect"]) {
+                    section.score++;
+                }
+            }
+        })
+        questionNumber++;
+    }
+    breakdown.sections.forEach(section => {
+        section.percentage = 100 * section.score / section.questions;
+    })
+    return breakdown;
+}
+
 async function addEventListenersForDownloadButtons() {
     document.querySelectorAll('.download-user-results-button').forEach((button) => {
         button.addEventListener("click", (e: any) => {

--- a/app/js/handlebarsScoreTable.ts
+++ b/app/js/handlebarsScoreTable.ts
@@ -245,7 +245,7 @@ async function createUserResultsBreakdown(resultData, test_id: string): Promise<
         questionNumber++;
     }
     breakdown.sections.forEach(section => {
-        section.percentage = 100 * section.score / section.questions;
+        section.percentage = Math.round(100 * section.score / section.questions);
     })
     return breakdown;
 }
@@ -273,8 +273,11 @@ async function addEventListenersForDownloadButtons() {
  */
 async function addEventListenersForViewResults() {
     let userResultsTemplate = await getTemplateAjax("js/templates/userResults.hbs");
+    let userResultsBreakdownTemplate = await getTemplateAjax("js/templates/userResultsBreakdown.hbs");
     let template: Function = Handlebars.compile(userResultsTemplate);
+    let breakdownTemplate: Function = Handlebars.compile(userResultsBreakdownTemplate);
     let resultsTable: Element = document.querySelector("#view-results-modal-content");
+    let resultsBreakdownTable: Element = document.querySelector("#view-results-breakdown-modal-content");
     document.querySelectorAll(".view-results-button").forEach((button) => {
         button.addEventListener("click", (e: any) => {
             openViewResultsModal();
@@ -287,6 +290,10 @@ async function addEventListenersForViewResults() {
                             getData("question?test_id=" + testId).then(questionData => {
                                 resultsTable.innerHTML = template(createUserResults(resultData, questionData));
                             })
+                            createUserResultsBreakdown(resultData, testId)
+                                .then(breakdown => {
+                                    resultsBreakdownTable.innerHTML = breakdownTemplate(breakdown);
+                                })
                         }
                     })
                 });

--- a/app/js/handlebarsScoreTable.ts
+++ b/app/js/handlebarsScoreTable.ts
@@ -222,11 +222,11 @@ async function createUserResultsBreakdown(resultData, test_id: string): Promise<
         breakdown.sections.push({name: 'Sequence', score: 0, questions: 0, percentage: 0, startingQuestionNumber: 24, finalQuestionNumber: 30});
     }
 
-    let testName = 'Test'
+    let testName = 'Total'
     let testData = await getData("test")
     testData.data.forEach(test => {
         if (test.id == test_id) {
-            testName = test.name
+            testName += ` (${test.name})`
         }
     })
     breakdown.sections.push({name: testName, score: 0, questions: 0, percentage: 0});

--- a/app/js/templates/userResultsBreakdown.hbs
+++ b/app/js/templates/userResultsBreakdown.hbs
@@ -1,0 +1,18 @@
+ <table class="table">
+     <thead>
+         <tr class="d-flex">
+             <th scope="col" class="col-2">Section</th>
+             <th scope="col" class="col-1">Questions</th>
+             <th scope="col" class="col-1">Percentage</th>
+         </tr>
+     </thead>
+     <tbody>
+         {{#each sections}}
+         <tr>
+             <td>{{name}}</td>
+             <td>{{questions}}</td>
+             <td>{{percentage}}%</td>
+         </tr>
+         {{/each}}
+     </tbody>
+ </table>

--- a/app/js/templates/userResultsBreakdown.hbs
+++ b/app/js/templates/userResultsBreakdown.hbs
@@ -1,7 +1,7 @@
  <table class="table">
      <thead>
          <tr class="d-flex">
-             <th scope="col" class="col-2">Section</th>
+             <th scope="col" class="col-4">Section</th>
              <th scope="col" class="col-1">Questions</th>
              <th scope="col" class="col-1">Percentage</th>
          </tr>

--- a/app/scss/adminPage.scss
+++ b/app/scss/adminPage.scss
@@ -214,3 +214,9 @@ input[type="number"] {
 .user-information-secondary-data-row {
   border-bottom: 3px solid #ddd;
 }
+
+#view-results-modal {
+  .active-tab {
+    background-color: $primary-button-hover;
+  }
+}


### PR DESCRIPTION
Added new tab buttons - Answers & Breakdown in user results modal
Created function createUserResultsBreakdown to create user score breakdown object
Created new handlebars template userResultsBreakdown.hbs to display the broken down scores & modified testName to display section name as total
Added functionality to load breakdown tables on adminPage load & added functionality to round %s to no decimal places
Added event listeners to tabbing buttons that toggle which table is being displayed
Display answers table & not breakdown table on opening view results modal
Visible change on tab buttons depending on your current tab